### PR TITLE
Let it work with non-ancient versions of Packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Version 0.1
 
 Condensation is a tool for building images for compute clusters using Apache Mesos and Spark. Currently it only supports Docker images, but the build system (packer) is flexible and can build images for VMWare, OpenStack, etc. with a little more work.
 
-You need Docker and Packer.io to use this.
+You need Docker and Packer.io v1.1.1 to use this. Not guarenteed to work with newer versions of Packer, but it just might.
 
 The included compose.yml can set up a simulated cluster on your own machine. It uses Docker-Compose.
 

--- a/compute/compute.packer.json
+++ b/compute/compute.packer.json
@@ -11,7 +11,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "centos:centos6",
+      "image": "centos:centos7",
       "export_path": "_builds/compute.docker.tgz"
     }
   ],
@@ -19,9 +19,8 @@
   "post-processors": [
     {
       "type": "docker-import",
-      "repository": "jbenjos/compute",
-      "tag": "{{user `condensation_version`}}",
-      "latest": true
+      "repository": "allnatural/compute",
+      "tag": "{{user `condensation_version`}}"
     }
   ],
 

--- a/compute/master/compute-master.packer.json
+++ b/compute/master/compute-master.packer.json
@@ -21,8 +21,7 @@
     {
       "type": "docker-import",
       "repository": "jbenjos/compute-master",
-      "tag": "{{user `condensation_version`}}",
-      "latest": true
+      "tag": "{{user `condensation_version`}}"
     }
   ],
   

--- a/compute/worker/compute-worker.packer.json
+++ b/compute/worker/compute-worker.packer.json
@@ -21,8 +21,7 @@
     {
       "type": "docker-import",
       "repository": "jbenjos/compute-worker",
-      "tag": "{{user `condensation_version`}}",
-      "latest": true
+      "tag": "{{user `condensation_version`}}"
     }
   ],
   


### PR DESCRIPTION
The templates are broken with the newest version of packer. This fixes this.